### PR TITLE
Fix colcon build error due to Autoware's recent tier4_autoware_utils package name change.

### DIFF
--- a/include/trajectory_loader/trajectory_loader_node.hpp
+++ b/include/trajectory_loader/trajectory_loader_node.hpp
@@ -22,7 +22,7 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tier4_autoware_utils/geometry/geometry.hpp>
+#include <autoware/universe_utils/geometry/geometry.hpp>
 
 #include "trajectory_loader/trajectory_loader.hpp"
 

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tier4_autoware_utils</depend>
+  <depend>autoware_universe_utils</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/src/trajectory_loader_node.cpp
+++ b/src/trajectory_loader_node.cpp
@@ -64,7 +64,7 @@ Trajectory TrajectoryLoaderNode::createTrajectory(const Points & points)
   for (auto & point : points) {
     TrajectoryPoint trajectory_point;
     Pose pose;
-    auto q = tier4_autoware_utils::createQuaternionFromYaw(point[2]);
+    auto q =  autoware_universe_utils::createQuaternionFromYaw(point[2]);
     pose.position.x = point[0];
     pose.position.y = point[1];
     pose.position.z = 0.0;

--- a/src/trajectory_loader_node.cpp
+++ b/src/trajectory_loader_node.cpp
@@ -64,7 +64,7 @@ Trajectory TrajectoryLoaderNode::createTrajectory(const Points & points)
   for (auto & point : points) {
     TrajectoryPoint trajectory_point;
     Pose pose;
-    auto q =  autoware_universe_utils::createQuaternionFromYaw(point[2]);
+    auto q =  autoware::universe_utils::createQuaternionFromYaw(point[2]);
     pose.position.x = point[0];
     pose.position.y = point[1];
     pose.position.z = 0.0;


### PR DESCRIPTION
Renamed tier4_autoware_utils package and function calls to autoware_universe_utils caused by the following issues and pull requests:

* https://github.com/autowarefoundation/autoware.universe/pull/7538
* https://github.com/orgs/autowarefoundation/discussions/4881
* https://github.com/orgs/autowarefoundation/discussions/4855